### PR TITLE
feat(component): adicionar botão customizado com estilos primário/secundário e hover

### DIFF
--- a/src/components/ui/header-button.tsx
+++ b/src/components/ui/header-button.tsx
@@ -1,0 +1,32 @@
+import * as React from "react";
+import { cn } from "@/lib/utils";
+import { Button as ShadButton } from "@/components/ui/button";
+
+interface CustomButtonProps
+  extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  secondary?: boolean;
+}
+
+export const CustomButton = React.forwardRef<
+  HTMLButtonElement,
+  CustomButtonProps
+>(({ className, secondary, children, ...props }, ref) => {
+  return (
+    <ShadButton
+      ref={ref}
+      className={cn(
+        "rounded-full px-6 py-2 font-semibold transition-all duration-300 shadow-sm",
+        "hover:scale-105 hover:shadow-md",
+        secondary
+          ? "bg-[#EDE9D5] text-black hover:bg-[#ddd7c4]"
+          : "bg-[#F6EEC9] text-black hover:bg-[#ebdfb8]",
+        className
+      )}
+      {...props}
+    >
+      {children}
+    </ShadButton>
+  );
+});
+
+CustomButton.displayName = "CustomButton";


### PR DESCRIPTION
# Mudanças
Adicionado componente CustomButton baseado no Shadcn Button. Suporte para variações primária e secundária. Adicionada animação de hover suave. Pode receber  uma função de onclick

## User Story
Tarefa número 5 do backlog

## Como testar
Pode ser testado diretamente na página da home, usei o seguinte código para teste:
```
import { Link } from "@tanstack/react-router"
import { CustomButton } from "@/components/ui/button"
import { Mountain, User } from "lucide-react"

export default function Header() {
  return (
    <header className="p-4 flex gap-4 bg-[#F8F6F0] text-black justify-between items-center">
      <Link to="/" className="no-underline">
        <CustomButton onClick={() => console.log("Ir para Home")}>
          <Mountain className="mr-2 h-5 w-5" />
          Início
        </CustomButton>
      </Link>

      <Link to="/" className="no-underline">
        <CustomButton secondary onClick={() => console.log("Ir para Perfil")}>
          João da Silva
          <User className="ml-2 h-5 w-5" />
        </CustomButton>
      </Link>
    </header>
  )
}
```
## Acceptance Criteria
- [X] Usar o [botão do shadcn](https://ui.shadcn.com/docs/components/button)
- [X] Botão deve ter hover
- [X] Deve poder receber uma função de onclick
- [X] Deve ter uma flag para estilização secundária (Meu Perfil)
