### PR TITLE
Feature/text input

### DIFF
--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -1,0 +1,21 @@
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+function Input({ className, type, ...props }: React.ComponentProps<"input">) {
+  return (
+    <input
+      type={type}
+      data-slot="input"
+      className={cn(
+        "file:text-foreground placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground dark:bg-input/30 border-input flex h-9 w-full min-w-0 rounded-md border bg-transparent px-3 py-1 text-base shadow-xs transition-[color,box-shadow] outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
+        "focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]",
+        "aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export { Input }

--- a/src/components/ui/textInput.tsx
+++ b/src/components/ui/textInput.tsx
@@ -1,0 +1,17 @@
+import * as React from "react";
+
+import { Input } from "@/components/ui/input"
+
+interface textInputProps {
+    children?: React.ReactNode;
+    label: string;
+}
+
+export function textInput({children, label}: textInputProps) {
+    return (
+        <div className="flex flex-col gap-2">
+            {children && <label>{children}</label>}
+                <Input type="text" placeholder={label}/>
+        </div>
+    )
+}

--- a/src/components/ui/textInput.tsx
+++ b/src/components/ui/textInput.tsx
@@ -2,16 +2,30 @@ import * as React from "react";
 
 import { Input } from "@/components/ui/input"
 
-interface textInputProps {
+import { cn } from "@/lib/utils"
+
+interface textInputProps extends React.ComponentProps<typeof Input> {
     children?: React.ReactNode;
-    label: string;
+    labelClassName: string;
+    wrapperClassName?: string;  
 }
 
-export function textInput({children, label}: textInputProps) {
+export function textInput({
+    children,
+    placeholder,
+    wrapperClassName,
+    labelClassName,
+    className,
+    ...Props
+    }: textInputProps) {
     return (
-        <div className="flex flex-col gap-2">
-            {children && <label>{children}</label>}
-                <Input type="text" placeholder={label}/>
+        <div className={cn("flex flex-col gap-2", wrapperClassName)}>
+            {children && <label className={cn("text-sm font--medium", labelClassName)}>{children}</label>}
+                <Input 
+                placeholder={placeholder}
+                className={cn("", className)} 
+                {...Props}
+                />
         </div>
     )
 }


### PR DESCRIPTION
# Mudanças

Criado o textInput com possibilidade de ajuste de estilização na hora da utilização do componente

## Como testar

Conforme orientação do João, não tem pagina de testes ainda. 

## Acceptance Criteria

- Importar [Input do shadcn](https://ui.shadcn.com/docs/components/input)
- Label do input deve poder receber qualquer React Node (Children)
- Placeholder como prop

## Screenshots da tela/componente desenvolvido
<img width="1136" height="785" alt="imagem_2025-08-27_184301445" src="https://github.com/user-attachments/assets/8ed21f63-01cd-4e8d-b4f8-12fdb50b5a41" />

## Observações
