### PR TITLE
feat(85): cria página de visualizar reserva

### DIFF
--- a/src/components/forms/reservationForm.tsx
+++ b/src/components/forms/reservationForm.tsx
@@ -1,0 +1,168 @@
+import { z } from "zod";
+import { useFieldArray, useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import {
+    Form,
+    FormControl,
+    FormField,
+    FormItem,
+    FormLabel,
+    FormMessage,
+} from "@/components/ui/form";
+import { TextInput } from "@/components/inputs/textInput";
+import {
+    Select,
+    SelectContent,
+    SelectItem,
+    SelectTrigger,
+    SelectValue,
+} from "@/components/ui/select";
+import { Button } from "@/components/buttons/defaultButton";
+import { maskCpf, maskPhone, isValidCpf } from "@/lib/utils";
+
+const userSchema = z.object({
+    id: z.number().optional(),
+    name: z.string().min(3, "O nome completo é obrigatório."),
+    phone: z.string().min(14, "O telefone é obrigatório (mínimo 14 caracteres)."),
+    birthDate: z.string().min(10, "A data de nascimento é obrigatória."),
+    cpf: z.string().refine(isValidCpf, "O CPF informado é inválido."),
+    gender: z.enum(["masculino", "feminino", "outro"], {
+        message: "Por favor, selecione um gênero.",
+    }),
+});
+
+const reservationSchema = z.object({
+    users: z.array(userSchema),
+});
+
+export type ReservationFormData = z.infer<typeof reservationSchema>;
+
+interface ReservationFormProps {
+    initialData: ReservationFormData;
+    isEditable: boolean;
+    onSubmit: (data: ReservationFormData) => void;
+}
+
+export function ReservationForm({
+                                    initialData,
+                                    isEditable,
+                                    onSubmit,
+                                }: ReservationFormProps) {
+    const form = useForm<ReservationFormData>({
+        resolver: zodResolver(reservationSchema),
+        mode: "onBlur",
+        defaultValues: initialData,
+    });
+
+    const { fields } = useFieldArray({
+        control: form.control,
+        name: "users",
+    });
+
+    return (
+        <Form {...form}>
+            <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-8">
+                <div className="space-y-6">
+                    {fields.map((field, index) => (
+                        <div key={field.id} className="p-4">
+                            <div className="grid grid-cols-1 md:grid-cols-5 gap-x-4 gap-y-0 items-start">
+                                <FormField
+                                    control={form.control}
+                                    name={`users.${index}.name`}
+                                    render={({ field }) => (
+                                        <FormItem>
+                                            <FormLabel>Nome *</FormLabel>
+                                            <FormControl>
+                                                <TextInput className="border-gray-900 mb-0" placeholder="Nome completo" disabled={!isEditable} {...field} />
+                                            </FormControl>
+                                            <FormMessage />
+                                        </FormItem>
+                                    )}
+                                />
+                                <FormField
+                                    control={form.control}
+                                    name={`users.${index}.phone`}
+                                    render={({ field }) => (
+                                        <FormItem>
+                                            <FormLabel>Telefone *</FormLabel>
+                                            <FormControl>
+                                                <TextInput
+                                                    className="border-gray-900 mb-0"
+                                                    placeholder="(XX) XXXXX-XXXX"
+                                                    disabled={!isEditable}
+                                                    {...field}
+                                                    onChange={(e) => field.onChange(maskPhone(e.target.value))}
+                                                />
+                                            </FormControl>
+                                            <FormMessage />
+                                        </FormItem>
+                                    )}
+                                />
+                                <FormField
+                                    control={form.control}
+                                    name={`users.${index}.birthDate`}
+                                    render={({ field }) => (
+                                        <FormItem>
+                                            <FormLabel>Data de Nascimento *</FormLabel>
+                                            <FormControl>
+                                                <TextInput className="border-gray-900 mb-0" placeholder="DD/MM/AAAA" disabled={!isEditable} {...field} />
+                                            </FormControl>
+                                            <FormMessage />
+                                        </FormItem>
+                                    )}
+                                />
+                                <FormField
+                                    control={form.control}
+                                    name={`users.${index}.cpf`}
+                                    render={({ field }) => (
+                                        <FormItem>
+                                            <FormLabel>CPF *</FormLabel>
+                                            <FormControl>
+                                                <TextInput
+                                                    className="border-gray-900 mb-0"
+                                                    placeholder="000.000.000-00"
+                                                    disabled={!isEditable}
+                                                    {...field}
+                                                    onChange={(e) => field.onChange(maskCpf(e.target.value))}
+                                                />
+                                            </FormControl>
+                                            <FormMessage />
+                                        </FormItem>
+                                    )}
+                                />
+                                <FormField
+                                    control={form.control}
+                                    name={`users.${index}.gender`}
+                                    render={({ field }) => (
+                                        <FormItem>
+                                            <FormLabel>Gênero *</FormLabel>
+                                            <Select onValueChange={field.onChange} value={field.value} disabled={!isEditable}>
+                                                <FormControl className="border-gray-900 mb-0">
+                                                    <SelectTrigger>
+                                                        <SelectValue placeholder="Selecione" />
+                                                    </SelectTrigger>
+                                                </FormControl>
+                                                <SelectContent>
+                                                    <SelectItem value="masculino">Masculino</SelectItem>
+                                                    <SelectItem value="feminino">Feminino</SelectItem>
+                                                    <SelectItem value="outro">Outro</SelectItem>
+                                                </SelectContent>
+                                            </Select>
+                                            <FormMessage />
+                                        </FormItem>
+                                    )}
+                                />
+                            </div>
+                        </div>
+                    ))}
+                </div>
+
+                <div className="flex justify-end">
+                    {isEditable && (
+                        <Button type="submit" label="Salvar Alterações" variant="primary" className="w-48" />
+                    )}
+                </div>
+            </form>
+        </Form>
+    );
+}

--- a/src/routes/(index)/reserve/view-reservation.tsx
+++ b/src/routes/(index)/reserve/view-reservation.tsx
@@ -1,0 +1,91 @@
+import { useState } from "react";
+import { createFileRoute, useNavigate } from "@tanstack/react-router";
+import { toast } from "sonner";
+import Layout from "@/components/layouts/dashboard";
+import { Typography } from "@/components/typography";
+import { Button } from "@/components/buttons/defaultButton";
+import { SummaryExperience } from "@/components/display";
+import { ReservationForm, type ReservationFormData } from "@/components/forms/reservationForm";
+import type { Locale } from "@/types/locale";
+
+const mockUsersData = {
+    users: [
+        { id: 1, name: "Ana Beatriz Costa", phone: "(51) 99999-9999", birthDate: "15/08/1990", cpf: "123.456.789-01", gender: "feminino" as const },
+        { id: 2, name: "Carlos Eduardo Lima", phone: "(51) 98888-8888", birthDate: "22/12/1995", cpf: "987.654.321-02", gender: "masculino" as const },
+        { id: 3, name: "Mariana Almeida", phone: "(51) 97777-7777", birthDate: "11/03/2000", cpf: "111.222.333-03", gender: "feminino" as const },
+    ],
+};
+
+const mockExperiences: {id: number, experience: string, startDate: string, endDate: string, price: number, capacity: number, locale: Locale}[] = [
+    { id: 1, experience: "Trilha na Serra Gaúcha", startDate: "2025-10-20T00:00:00.000Z", endDate: "2025-10-22T00:00:00.000Z", price: 450.0, capacity: 15, locale: "pt-BR" }
+];
+
+
+export const Route = createFileRoute("/(index)/reserve/view-reservation")({
+    component: VisualizarReservaPage,
+});
+
+function VisualizarReservaPage() {
+    const navigate = useNavigate();
+    const [isEditable, setIsEditable] = useState(false);
+
+    const handleFormSubmit = (data: ReservationFormData) => {
+        console.log("Dados da reserva atualizados:", data);
+        toast.success("Reserva atualizada com sucesso!");
+        setIsEditable(false);
+    };
+
+    const handleBackClick = () => {
+        navigate({ to: '/user/my-reservations'});
+    };
+
+
+    return (
+        <Layout>
+            <Layout.Content className="bg-gray-50 py-8">
+                <main className="max-w-6xl mx-auto p-8 bg-white rounded-lg border border-gray-200 shadow-sm">
+                    <div className="flex justify-between items-center mb-6">
+                        <Typography variant="h2" className="text-2xl font-semibold">
+                            {isEditable ? "Editar Reserva" : "Visualizar Reserva"}
+                        </Typography>
+                        {!isEditable && (
+                            <Button
+                                label="Editar Reserva"
+                                variant="ghost"
+                                onClick={() => setIsEditable(true)}
+                            />
+                        )}
+                    </div>
+                    <ReservationForm
+                        initialData={mockUsersData}
+                        isEditable={isEditable}
+                        onSubmit={handleFormSubmit}
+                    />
+
+                    <div className="my-8 p-4 bg-gray-50 rounded-md border">
+                        <Typography variant="body" className="text-muted-foreground text-sm">
+                            Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aliquam gravida massa et metus rhoncus gravida. Sed elementum velit purus.
+                        </Typography>
+                    </div>
+
+                    <div className="grid grid-cols-1 md:grid-cols-2 gap-8">
+                        {mockExperiences.map((xp) => (
+                            <SummaryExperience key={xp.id} {...xp} />
+                        ))}
+                    </div>
+
+                    <div className="mt-12 flex justify-end gap-4">
+                        <Button
+                            type="button"
+                            label={isEditable ? "Cancelar" : "Voltar"}
+                            variant="secondary"
+                            className="w-40"
+                            onClick={isEditable ? () => setIsEditable(false) : handleBackClick}
+                        />
+                    </div>
+
+                </main>
+            </Layout.Content>
+        </Layout>
+    );
+}


### PR DESCRIPTION
Cria o componente reutilizável ReservationForm para gerenciar os dados dos participantes de uma reserva, encapsulando a lógica de validação com Zod e o gerenciamento de estado com React Hook Form. Implementa a página view-reservation que utiliza o novo formulário para exibir os dados da reserva. Adiciona funcionalidade para alternar entre os modos de visualização e edição na mesma página.

## Como testar

Suba a aplicação, faça login e acesse o endpoint '/reserve/view-reservation'


## Acceptance Criteria

- [X] Cliente deve conseguir visualizar sua reserva recém finalizada

## Observação

Não foi feita a integração com o backend.