### PR TITLE
fix(160): mudança do name na tabela de experiencias para nome

### DIFF
--- a/src/routes/admin/experiences/index.tsx
+++ b/src/routes/admin/experiences/index.tsx
@@ -70,7 +70,7 @@ function RouteComponent() {
   const columns = [
     {
       accessorKey: 'name',
-      header: 'Name',
+      header: 'Nome',
       enableSorting: true,
     },
     {


### PR DESCRIPTION
# Mudanças
* Ajuste no cabeçalho da tabela de experiências: "Name" → "Nome" na coluna `name`.

## Como testar
- 1. Build e navegação
  * Suba o frontend e navegue até /admin/experiences autenticado como admin.

- 2. Verificar cabeçalho
  * Confirme que a primeira coluna exibe “Nome” (e não “Name”).

## Acceptance Criteria

- [X] A coluna `name` deve exibir o cabeçalho **"Nome"** na tela `/admin/experiences`.
